### PR TITLE
Generer ES-query for stillingskategori på en generisk måte.

### DIFF
--- a/src/formidling/Formidlingssøk.tsx
+++ b/src/formidling/Formidlingssøk.tsx
@@ -18,14 +18,15 @@ export interface IAlleFormidlinger {
 }
 
 /* Hentet ut som konstant, så den alltid har samme identitet, siden
-den brukes i dependency på en useEffect eller lignende.
+ * den brukes i dependency på en useEffect eller lignende.
  */
 const kunFormidling = new Set([Stillingskategori.Formidling]);
 
 const Formidlingssøk: React.FC<IAlleFormidlinger> = ({ navIdent }) => {
     const respons = useSøkMedQuery({
         navIdent,
-        overstyrMedStillingskategori: kunFormidling,
+        overstyrValgteStillingskategorier: kunFormidling,
+        fallbackIngenValgteStillingskategorier: kunFormidling,
     });
 
     const globalAggregering = respons?.aggregations

--- a/src/stilling/stillingssok/AlleStillinger.tsx
+++ b/src/stilling/stillingssok/AlleStillinger.tsx
@@ -10,14 +10,22 @@ import Stillingsliste from './stillingsliste/Stillingsliste';
 import Søkefelter from './søkefelter/Søkefelter';
 import useAntallTreff from './useAntallTreff';
 import useSøkMedQuery from './useSøkMedQuery';
+import { Stillingskategori } from 'felles/domene/stilling/Stilling';
 
 export type Props = {
     kandidatnr: string;
     finnerStillingForKandidat?: boolean;
 };
 
+export const fallbackIngenValgteStillingskategorier = new Set([
+    Stillingskategori.Stilling,
+    Stillingskategori.Jobbmesse,
+]);
+
 const AlleStillinger = ({ kandidatnr, finnerStillingForKandidat }: Props) => {
-    const respons = useSøkMedQuery({});
+    const respons = useSøkMedQuery({
+        fallbackIngenValgteStillingskategorier,
+    });
 
     const globalAggregering = respons?.aggregations
         ?.globalAggregering as unknown as GlobalAggregering;

--- a/src/stilling/stillingssok/MineStillinger.tsx
+++ b/src/stilling/stillingssok/MineStillinger.tsx
@@ -10,6 +10,7 @@ import Stillingsliste from './stillingsliste/Stillingsliste';
 import Søkefelter from './søkefelter/Søkefelter';
 import useAntallTreff from './useAntallTreff';
 import useSøkMedQuery from './useSøkMedQuery';
+import { fallbackIngenValgteStillingskategorier } from './AlleStillinger';
 
 export type Props = {
     navIdent: string;
@@ -18,7 +19,11 @@ export type Props = {
 };
 
 const MineStillinger = ({ navIdent, kandidatnr, finnerStillingForKandidat }: Props) => {
-    const respons = useSøkMedQuery({ navIdent, ikkePubliserte: true });
+    const respons = useSøkMedQuery({
+        navIdent,
+        ikkePubliserte: true,
+        fallbackIngenValgteStillingskategorier,
+    });
     const globalAggregering = respons?.aggregations
         ?.globalAggregering as unknown as GlobalAggregering;
 

--- a/src/stilling/stillingssok/api/queries/stillingskategori.ts
+++ b/src/stilling/stillingssok/api/queries/stillingskategori.ts
@@ -1,80 +1,57 @@
 import { Stillingskategori } from 'felles/domene/stilling/Stilling';
 
-export const stillingskategori = (stillingskategori: Set<Stillingskategori>) => {
-    const skalInkluderes = Array.from(stillingskategori).map((kategori) => ({
-        term: {
-            'stillingsinfo.stillingskategori': kategori,
-        },
-    }));
+type IStillingskategori = {
+    fallbackIngenValgte: Set<Stillingskategori>;
+    valgte: Set<Stillingskategori>;
+};
 
-    // Formidlingsside
-    if (stillingskategori.has(Stillingskategori.Formidling)) {
-        return [
-            {
-                bool: {
-                    should: skalInkluderes,
-                },
-            },
-        ];
+export const stillingskategori = ({ valgte, fallbackIngenValgte }: IStillingskategori) => {
+    if (valgte.size === 0) {
+        valgte = fallbackIngenValgte;
     }
 
-    // Stillingsside
-    // ingen valgt eller begge valgt (Stilling og Jobbmesse)
-    if (
-        stillingskategori.size === 0 ||
-        (stillingskategori.has(Stillingskategori.Stilling) &&
-            stillingskategori.has(Stillingskategori.Jobbmesse))
-    ) {
-        return [
-            {
-                bool: {
-                    must_not: [
-                        {
-                            term: {
-                                'stillingsinfo.stillingskategori': Stillingskategori.Formidling,
-                            },
-                        },
-                    ],
-                },
-            },
-        ];
-    }
+    /** Filtrering på stillingskategori (`stillingsinfo.stillingskategori`) kan ikke gjøres naivt:
+     *  - eksterne stillinger uten kandidatlister har ingen kategori (`stillingsinfo` er null).
+     *  - elasticsearch skiller ikke mellom null og om felt mangler.
+     *
+     * Vi filtrere derfor på stillingskategori på to måter:
+     * 1. Om stillinger skal være en del av resultatet, filtrerer vi bort det som ikke er valgt.
+     * 2. Om stillinger ikke skal være en del av resultatet, filtrerer man direkte på det som er valgt.
+     */
 
-    // Stilling valgt
-    if (stillingskategori.has(Stillingskategori.Stilling)) {
-        return [
-            {
-                bool: {
-                    must_not: [
-                        {
-                            term: {
-                                'stillingsinfo.stillingskategori': Stillingskategori.Jobbmesse,
-                            },
-                        },
-                        {
-                            term: {
-                                'stillingsinfo.stillingskategori': Stillingskategori.Formidling,
-                            },
-                        },
-                    ],
-                },
-            },
-        ];
-    }
-    // Jobbmesse valgt
-    if (stillingskategori.has(Stillingskategori.Jobbmesse)) {
-        return [
-            {
-                bool: {
-                    must: [
-                        {
-                            term: {
-                                'stillingsinfo.stillingskategori': Stillingskategori.Jobbmesse,
-                            },
-                        },
-                    ],
-                },
-            },
-        ];
+    if (valgte.has(Stillingskategori.Stilling)) {
+        const ikkeValgte = motsatteValg(valgte);
+        return ekskluderKategorier(ikkeValgte);
+    } else {
+        return visKunKategorier(valgte);
     }
 };
+
+const motsatteValg = (valgteKategorier: Set<Stillingskategori>) => {
+    const alleKategorier = Object.values(Stillingskategori);
+    return new Set(alleKategorier.filter((kategori) => !valgteKategorier.has(kategori)));
+};
+
+const visKunKategorier = (stillingskategorier: Set<Stillingskategori>) => [
+    {
+        bool: {
+            should: [...stillingskategorier].map((kategori) => ({
+                term: {
+                    'stillingsinfo.stillingskategori': kategori,
+                },
+            })),
+        },
+    },
+];
+
+const ekskluderKategorier = (stillingskategorier: Set<Stillingskategori>) => [
+    {
+        bool: {
+            must_not: [...stillingskategorier].map((kategori) => ({
+                term: {
+                    'stillingsinfo.stillingskategori': kategori,
+                },
+            })),
+        },
+    },
+];

--- a/src/stilling/stillingssok/utvikling/ForklarMatch.tsx
+++ b/src/stilling/stillingssok/utvikling/ForklarMatch.tsx
@@ -8,6 +8,7 @@ import { søk } from '../api/api';
 import { lagIndreQuery } from '../api/queries/queries';
 import { hentSøkekriterier } from '../utils/urlUtils';
 import css from './Utviklingsapp.module.css';
+import { fallbackIngenValgteStillingskategorier } from '../AlleStillinger';
 
 const ForklarMatch = () => {
     const { stillingsId } = useParams();
@@ -19,7 +20,10 @@ const ForklarMatch = () => {
     useEffect(() => {
         const hentForklaringMedStillingsId = async (stillingsId: string) => {
             const query = {
-                query: lagIndreQuery({ søkekriterier }),
+                query: lagIndreQuery({
+                    søkekriterier,
+                    fallbackIngenValgteStillingskategorier,
+                }),
             };
 
             const respons = await søk(query, true);


### PR DESCRIPTION
Ser også at aggregat må få tak i stillingskategoriene i sin query.