### PR TITLE
Bytt til oppslag av kandidatliste basert på stillingsid

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ jobs:
     deploy-til-dev:
         name: Deploy til dev-gcp
         needs: bygg-og-push-docker-image
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/resette-legg-til-boks'
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/fjern_kandidatlisteoppslag'
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3

--- a/mock/kandidat-api/mock.ts
+++ b/mock/kandidat-api/mock.ts
@@ -32,17 +32,6 @@ export const kandidatApiMock = [
             : new HttpResponse(null, { status: 404 });
     }),
 
-    http.get(`${api.kandidat}/veileder/kandidatlister/:kandidatlisteId`, ({ params }) => {
-        const { kandidatlisteId } = params;
-        const kandidatlisteUtenStilling = mockAlleKandidatlister.find(
-            (liste) => liste.kandidatlisteId === kandidatlisteId
-        );
-
-        return kandidatlisteUtenStilling
-            ? HttpResponse.json(kandidatlisteUtenStilling)
-            : new HttpResponse(null, { status: 404 });
-    }),
-
     http.delete(
         `${api.kandidat}/veileder/kandidatlister/:kandidatlisteId`,
         (_) => new HttpResponse(null, { status: 200 })

--- a/src/felles/lenker.ts
+++ b/src/felles/lenker.ts
@@ -17,3 +17,9 @@ export const lenkeTilStilling = (props: ILenkeTilStilling) => {
 
     return path;
 };
+
+export enum KandidatsokQueryParam {
+    Stilling = 'stilling',
+    Kandidatliste = 'kandidatliste',
+    BrukKriterierFraStillingen = 'brukKriterierFraStillingen',
+}

--- a/src/kandidat/app/paths.ts
+++ b/src/kandidat/app/paths.ts
@@ -92,12 +92,10 @@ const queryParamsForKandidatside = (
     }
     const { kandidatlisteId, stillingId } = kandidatlistekontekst ?? {};
 
-    if (kandidatlisteId) {
-        queryParams.set(KandidatQueryParam.KandidatlisteId, kandidatlisteId);
-    }
-
     if (stillingId) {
         queryParams.set(KandidatQueryParam.StillingId, stillingId);
+    } else if (kandidatlisteId) {
+        queryParams.set(KandidatQueryParam.KandidatlisteId, kandidatlisteId);
     }
 
     return queryParams.size === 0 ? '' : `?${queryParams.toString()}`;

--- a/src/kandidat/app/paths.ts
+++ b/src/kandidat/app/paths.ts
@@ -1,6 +1,6 @@
 import { KandidatQueryParam } from '../kandidatside/Kandidatside';
 
-const nesteSeparator = (lenke: string) => (lenke.includes('?') ? '&' : '?');
+import { KandidatsokQueryParam } from 'felles/lenker';
 
 export const lenkeTilTilgangsside = `/kandidater/mangler-tilgang`;
 export const lenkeTilKandidatliste = (stillingId: string, filterQuery?: URLSearchParams) => {
@@ -13,18 +13,6 @@ export const lenkeTilKandidatliste = (stillingId: string, filterQuery?: URLSearc
     return lenke;
 };
 
-export const lenkeTilKandidat = (
-    kandidatnummer: string,
-    kandidatlisteId?: string,
-    stillingsId?: string
-) => {
-    const path = `/kandidater/kandidat/${kandidatnummer}/cv`;
-    if (kandidatlisteId) return path + `?${KandidatQueryParam.KandidatlisteId}=${kandidatlisteId}`;
-    if (stillingsId) return path + `?${KandidatQueryParam.StillingId}=${stillingsId}`;
-
-    return path;
-};
-
 export const lenkeTilKandidatsøk = (searchParams?: string) => {
     let url = '/kandidatsok';
 
@@ -35,82 +23,82 @@ export const lenkeTilKandidatsøk = (searchParams?: string) => {
     return url;
 };
 
-export const lenkeTilFinnKandidater = (
-    stillingId: string | null,
-    kandidatlisteId: string,
-    brukKriterierFraStillingen: boolean
-) => {
-    const brukKriterierFraStillingSuffiks = brukKriterierFraStillingen
-        ? '&brukKriterierFraStillingen=true'
-        : '';
-    return `/kandidatsok?kandidatliste=${kandidatlisteId}${brukKriterierFraStillingSuffiks}`;
+export const lenkeTilFinnKandidater = (stillingId: string) => {
+    const queryParams = new URLSearchParams();
+    queryParams.set(KandidatsokQueryParam.BrukKriterierFraStillingen, 'true');
+    queryParams.set(KandidatsokQueryParam.Stilling, stillingId);
+    return `/kandidatsok?${queryParams.toString()}`;
 };
-
-export const lenkeTilFinnKandidaterMedStilling = (stillingsId: string, params?: string) =>
-    `/kandidater/stilling/${stillingsId}${params ? '?' + params : ''}`;
-
-export const lenkeTilFinnKandidaterUtenStilling = (stillingsId: string, params?: string) =>
-    `/kandidater/kandidatliste/${stillingsId}${params ? '?' + params : ''}`;
-
-export const lenkeTilFinnKandidaterIKandidatsøk = (kandidatlisteId: string) =>
-    `/kandidatsok?kandidatliste=${kandidatlisteId}`;
 
 export enum Kandidatfane {
     Cv = 'cv',
     Historikk = 'historikk',
 }
 
+export type Kandidatlistekontekst = {
+    stillingId: string;
+    /** @deprecated  bruk stillingsId */
+    kandidatlisteId?: string;
+};
+
 export const lenkeTilKandidatside = (
     kandidatnr: string,
     aktivFane: Kandidatfane,
-    kandidatlisteId?: string,
+    kandidatlistekontekst?: Kandidatlistekontekst,
     fraKandidatliste?: boolean,
     fraKandidatsøk?: boolean
 ) =>
     aktivFane === Kandidatfane.Cv
-        ? lenkeTilCv(kandidatnr, kandidatlisteId, fraKandidatliste, fraKandidatsøk)
-        : lenkeTilHistorikk(kandidatnr, kandidatlisteId, fraKandidatliste, fraKandidatsøk);
+        ? lenkeTilCv(kandidatnr, kandidatlistekontekst, fraKandidatliste, fraKandidatsøk)
+        : lenkeTilHistorikk(kandidatnr, kandidatlistekontekst, fraKandidatliste, fraKandidatsøk);
 
 export const lenkeTilCv = (
     kandidatnr: string,
-    kandidatlisteId?: string,
+    kandidatlistekontekst?: Kandidatlistekontekst,
     fraKandidatliste?: boolean,
     fraKandidatsøk?: boolean
 ) => {
     let lenke = `/kandidater/kandidat/${kandidatnr}/cv`;
-    return lenke + queryParamsForKandidatside(kandidatlisteId, fraKandidatliste, fraKandidatsøk);
+    return (
+        lenke + queryParamsForKandidatside(kandidatlistekontekst, fraKandidatliste, fraKandidatsøk)
+    );
 };
 
 export const lenkeTilHistorikk = (
     kandidatnr: string,
-    kandidatlisteId?: string,
+    kandidatlistekontekst?: Kandidatlistekontekst,
     fraKandidatliste?: boolean,
     fraKandidatsøk?: boolean
 ) => {
     let lenke = `/kandidater/kandidat/${kandidatnr}/historikk`;
-    return lenke + queryParamsForKandidatside(kandidatlisteId, fraKandidatliste, fraKandidatsøk);
+    return (
+        lenke + queryParamsForKandidatside(kandidatlistekontekst, fraKandidatliste, fraKandidatsøk)
+    );
 };
 
 const queryParamsForKandidatside = (
-    kandidatlisteId?: string,
+    kandidatlistekontekst?: Kandidatlistekontekst,
     fraKandidatliste?: boolean,
     fraKandidatsøk?: boolean
 ) => {
-    let queryParams = '';
+    let queryParams = new URLSearchParams();
 
     if (fraKandidatliste) {
-        queryParams += nesteSeparator(queryParams) + `${KandidatQueryParam.FraKandidatliste}=true`;
+        queryParams.set(KandidatQueryParam.FraKandidatliste, 'true');
     }
 
     if (fraKandidatsøk) {
-        queryParams += nesteSeparator(queryParams) + `${KandidatQueryParam.FraKandidatsøk}=true`;
+        queryParams.set(KandidatQueryParam.FraKandidatsøk, 'true');
     }
+    const { kandidatlisteId, stillingId } = kandidatlistekontekst ?? {};
 
     if (kandidatlisteId) {
-        queryParams +=
-            nesteSeparator(queryParams) +
-            `${KandidatQueryParam.KandidatlisteId}=${kandidatlisteId}`;
+        queryParams.set(KandidatQueryParam.KandidatlisteId, kandidatlisteId);
     }
 
-    return queryParams;
+    if (stillingId) {
+        queryParams.set(KandidatQueryParam.StillingId, stillingId);
+    }
+
+    return queryParams.size === 0 ? '' : `?${queryParams.toString()}`;
 };

--- a/src/kandidat/kandidatliste/Kandidatlisteside.tsx
+++ b/src/kandidat/kandidatliste/Kandidatlisteside.tsx
@@ -10,35 +10,22 @@ import KandidatlisteActionType from '../../kandidat/kandidatliste/reducer/Kandid
 import AppState from '../../kandidat/state/AppState';
 
 type Props = {
-    stillingsId?: string;
-    kandidatlisteId: string;
     skjulBanner?: boolean;
-    stilling?: Stilling;
+    stilling: Stilling;
 };
 
-const Kandidatlisteside: FunctionComponent<Props> = ({
-    stillingsId,
-    kandidatlisteId,
-    skjulBanner,
-    stilling,
-}) => {
+const Kandidatlisteside: FunctionComponent<Props> = ({ skjulBanner, stilling }) => {
     const dispatch = useDispatch();
     const { kandidatliste } = useSelector((state: AppState) => state.kandidatliste);
+    const stillingsId = stilling.uuid;
     useScrollTilToppen(kandidatliste);
 
     useEffect(() => {
-        if (stillingsId) {
-            dispatch({
-                type: KandidatlisteActionType.HentKandidatlisteMedStillingsId,
-                stillingsId,
-            });
-        } else if (kandidatlisteId) {
-            dispatch({
-                type: KandidatlisteActionType.HentKandidatlisteMedKandidatlisteId,
-                kandidatlisteId,
-            });
-        }
-    }, [dispatch, stillingsId, kandidatlisteId]);
+        dispatch({
+            type: KandidatlisteActionType.HentKandidatlisteMedStillingsId,
+            stillingsId,
+        });
+    }, [dispatch, stillingsId]);
 
     if (kandidatliste.kind === Nettstatus.LasterInn) {
         return <Sidelaster />;
@@ -48,7 +35,7 @@ const Kandidatlisteside: FunctionComponent<Props> = ({
 
     if (
         kandidatliste.kind === Nettstatus.Suksess &&
-        kandidatlisteId !== kandidatliste.data.kandidatlisteId
+        stillingsId !== kandidatliste.data.stillingId
     ) {
         return <Sidelaster />;
     }

--- a/src/kandidat/kandidatliste/kandidatrad/Kandidatrad.tsx
+++ b/src/kandidat/kandidatliste/kandidatrad/Kandidatrad.tsx
@@ -131,7 +131,7 @@ const Kandidatrad: FunctionComponent<Props> = ({
                             className={classNames('navds-link', css.kolonneMedSmsLenke)}
                             to={lenkeTilCv(
                                 kandidat.kandidatnr,
-                                kandidatliste.kandidatlisteId,
+                                { stillingId: kandidatliste.stillingId },
                                 true
                             )}
                         >

--- a/src/kandidat/kandidatside/Kandidatside.tsx
+++ b/src/kandidat/kandidatside/Kandidatside.tsx
@@ -25,30 +25,29 @@ const Kandidatside: FunctionComponent = () => {
     const kandidatnr = routeParams.kandidatnr!;
 
     const kandidatlisteIdFraUrl = searchParams.get(KandidatQueryParam.KandidatlisteId);
+    const stillingIdFraUrl = searchParams.get(KandidatQueryParam.StillingId);
     const kommerFraKandidatliste = searchParams.get(KandidatQueryParam.FraKandidatliste) === 'true';
     const kommerFraKandidatsøket = searchParams.get(KandidatQueryParam.FraKandidatsøk) === 'true';
 
     if (kommerFraKandidatliste) {
-        if (kandidatlisteIdFraUrl) {
-            return (
-                <FraKandidatliste
-                    tabs={<Faner />}
-                    kandidatnr={kandidatnr}
-                    kandidatlisteId={kandidatlisteIdFraUrl}
-                >
-                    <Outlet />
-                </FraKandidatliste>
-            );
-        } else {
-            return <Sidefeil feilmelding="Mangler kandidatlisteId i URL" />;
-        }
+        return (
+            <FraKandidatliste
+                tabs={<Faner />}
+                kandidatnr={kandidatnr}
+                kandidatlisteId={kandidatlisteIdFraUrl}
+                stillingId={stillingIdFraUrl}
+            >
+                <Outlet />
+            </FraKandidatliste>
+        );
     } else if (kommerFraKandidatsøket) {
-        if (kandidatlisteIdFraUrl) {
+        if (stillingIdFraUrl || kandidatlisteIdFraUrl) {
             return (
                 <FraSøkMedKandidatliste
                     tabs={<Faner />}
                     kandidatnr={kandidatnr}
                     kandidatlisteId={kandidatlisteIdFraUrl}
+                    stillingId={stillingIdFraUrl}
                 >
                     <Outlet />
                 </FraSøkMedKandidatliste>

--- a/src/kandidat/kandidatside/fraKandidatliste/useNavigerbareKandidater.ts
+++ b/src/kandidat/kandidatside/fraKandidatliste/useNavigerbareKandidater.ts
@@ -25,7 +25,12 @@ const useNavigerbareKandidater = (
 
     const hentLenkeTilKandidat = (kandidatnummer: string) =>
         kandidatnummer
-            ? lenkeTilKandidatside(kandidatnummer, fane, kandidatliste.kandidatlisteId, true)
+            ? lenkeTilKandidatside(
+                  kandidatnummer,
+                  fane,
+                  { stillingId: kandidatliste.stillingId },
+                  true
+              )
             : undefined;
 
     const index = kandidatnumre.indexOf(kandidatnr);

--- a/src/kandidat/kandidatside/fraSøkMedKandidatliste/FraSøkMedKandidatliste.tsx
+++ b/src/kandidat/kandidatside/fraSøkMedKandidatliste/FraSøkMedKandidatliste.tsx
@@ -21,7 +21,8 @@ import LagreKandidatIKandidatlisteModal from './LagreKandidatIKandidatlisteModal
 type Props = {
     tabs: ReactNode;
     kandidatnr: string;
-    kandidatlisteId: string;
+    kandidatlisteId: string | null;
+    stillingId: string | null;
     children?: ReactNode;
 };
 
@@ -29,6 +30,7 @@ const FraSøkMedKandidatliste: FunctionComponent<Props> = ({
     tabs,
     kandidatnr,
     kandidatlisteId,
+    stillingId,
     children,
 }) => {
     useScrollTilToppen(kandidatnr);
@@ -37,8 +39,8 @@ const FraSøkMedKandidatliste: FunctionComponent<Props> = ({
     const [visLagreKandidatModal, setVisLagreKandidatModal] = useState<boolean>(false);
 
     const { cv } = useCv(kandidatnr);
-    const kandidatliste = useKandidatliste(kandidatlisteId);
-    const kandidatnavigering = useNavigerbareKandidaterFraSøk(kandidatnr, kandidatlisteId);
+    const kandidatliste = useKandidatliste({ stillingId, kandidatlisteId });
+    const kandidatnavigering = useNavigerbareKandidaterFraSøk(kandidatnr, {stillingId, kandidatlisteId});
 
     const økt = hentØktFraKandidatsøk();
 

--- a/src/kandidat/kandidatside/hooks/useKandidatliste.ts
+++ b/src/kandidat/kandidatside/hooks/useKandidatliste.ts
@@ -5,24 +5,37 @@ import AppState from '../../state/AppState';
 import KandidatlisteAction from '../../kandidatliste/reducer/KandidatlisteAction';
 import KandidatlisteActionType from '../../kandidatliste/reducer/KandidatlisteActionType';
 
-const useKandidatliste = (kandidatlisteId: string) => {
+type UseKandidatliste = {
+    stillingId: string | null;
+    /** @deprecated  bruk stillingsId */
+    kandidatlisteId?: string | null;
+};
+
+const useKandidatliste = ({ stillingId, kandidatlisteId }: UseKandidatliste) => {
     const dispatch: Dispatch<KandidatlisteAction> = useDispatch();
     const state = useSelector((state: AppState) => state.kandidatliste);
 
     useEffect(() => {
-        const hentKandidatliste = (kandidatlisteId: string) => {
+        const hentKandidatliste = () => {
             dispatch({
                 type: KandidatlisteActionType.NullstillKandidatliste,
             });
 
-            dispatch({
-                type: KandidatlisteActionType.HentKandidatlisteMedKandidatlisteId,
-                kandidatlisteId,
-            });
+            if (stillingId) {
+                dispatch({
+                    type: KandidatlisteActionType.HentKandidatlisteMedStillingsId,
+                    stillingsId: stillingId,
+                });
+            } else if (kandidatlisteId) {
+                dispatch({
+                    type: KandidatlisteActionType.HentKandidatlisteMedKandidatlisteId,
+                    kandidatlisteId,
+                });
+            }
         };
 
-        hentKandidatliste(kandidatlisteId);
-    }, [dispatch, kandidatlisteId]);
+        hentKandidatliste();
+    }, [dispatch, stillingId, kandidatlisteId]);
 
     return state.kandidatliste;
 };

--- a/src/kandidat/kandidatside/hooks/useNavigerbareKandidaterFraSøk.ts
+++ b/src/kandidat/kandidatside/hooks/useNavigerbareKandidaterFraSøk.ts
@@ -1,12 +1,12 @@
 import { useEffect, useState } from 'react';
-import { Kandidatfane, lenkeTilKandidatside } from '../../app/paths';
+import { Kandidatfane, Kandidatlistekontekst, lenkeTilKandidatside } from '../../app/paths';
 import { hentØktFraKandidatsøk, skrivØktTilSessionStorage } from '../søkekontekst';
 import { Kandidatnavigering } from '../komponenter/header/forrige-neste/ForrigeNeste';
 import useFaner from './useFaner';
 
 const useNavigerbareKandidaterFraSøk = (
     kandidatnr: string,
-    kandidatlisteId?: string
+    kandidatlistekontekst?: Kandidatlistekontekst
 ): Kandidatnavigering | null => {
     const [fane] = useFaner();
     const [økt, setØkt] = useState(hentØktFraKandidatsøk());
@@ -16,7 +16,7 @@ const useNavigerbareKandidaterFraSøk = (
         kandidatnr,
         økt.navigerbareKandidater,
         fane,
-        kandidatlisteId
+        kandidatlistekontekst
     );
 
     useEffect(() => {
@@ -57,7 +57,7 @@ const byggLenkeTilForrigeOgNesteKandidat = (
     currentKandidat: string,
     navigerbareKandidater: string[] | undefined,
     fane: Kandidatfane,
-    kandidatlisteId?: string
+    kandidatlistekontekst?: Kandidatlistekontekst
 ): [number, string | undefined, string | undefined] => {
     if (!navigerbareKandidater) {
         return [0, undefined, undefined];
@@ -69,11 +69,23 @@ const byggLenkeTilForrigeOgNesteKandidat = (
     }
 
     const forrige = navigerbareKandidater[index - 1]
-        ? lenkeTilKandidatside(navigerbareKandidater[index - 1], fane, kandidatlisteId, false, true)
+        ? lenkeTilKandidatside(
+              navigerbareKandidater[index - 1],
+              fane,
+              kandidatlistekontekst,
+              false,
+              true
+          )
         : undefined;
 
     const neste = navigerbareKandidater[index + 1]
-        ? lenkeTilKandidatside(navigerbareKandidater[index + 1], fane, kandidatlisteId, false, true)
+        ? lenkeTilKandidatside(
+              navigerbareKandidater[index + 1],
+              fane,
+              kandidatlistekontekst,
+              false,
+              true
+          )
         : undefined;
 
     return [index, forrige, neste];

--- a/src/kandidatsok/hooks/useKontekstAvKandidatlisteEllerStilling.ts
+++ b/src/kandidatsok/hooks/useKontekstAvKandidatlisteEllerStilling.ts
@@ -5,6 +5,8 @@ import { Nettressurs, Nettstatus } from 'felles/nettressurs';
 import { Navigeringsstate } from './useNavigeringsstate';
 import Kandidatliste from 'felles/domene/kandidatliste/Kandidatliste';
 
+import { KandidatsokQueryParam } from 'felles/lenker';
+
 export type KontekstAvKandidatlisteEllerStilling = {
     kandidatliste: Nettressurs<Kandidatliste>;
     stilling: Nettressurs<Stilling>;
@@ -16,9 +18,9 @@ const useKontekstAvKandidatlisteEllerStilling = (
     navigeringsstate: Navigeringsstate
 ): KontekstAvKandidatlisteEllerStilling | null => {
     const [searchParams] = useSearchParams();
-    const kandidatlisteId = searchParams.get('kandidatliste');
+    const kandidatlisteId = searchParams.get(KandidatsokQueryParam.Kandidatliste);
 
-    const stillingId = searchParams.get('stilling');
+    const stillingId = searchParams.get(KandidatsokQueryParam.Stilling);
     const [kandidatliste, setKandidatliste] = useState<Nettressurs<Kandidatliste>>({
         kind: Nettstatus.IkkeLastet,
     });

--- a/src/kandidatsok/hooks/useNavigeringsstate.ts
+++ b/src/kandidatsok/hooks/useNavigeringsstate.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useLocation, useSearchParams } from 'react-router-dom';
-import { OtherParam } from './useQuery';
+
+import { KandidatsokQueryParam } from 'felles/lenker';
 
 export type Navigeringsstate = Partial<{
     scrollTilKandidat: boolean;
@@ -9,7 +10,7 @@ export type Navigeringsstate = Partial<{
 }>;
 
 const skalBrukeKriterierFraStillingen = (searchParams: URLSearchParams) =>
-    Boolean(searchParams.get(OtherParam.BrukKriterierFraStillingen));
+    Boolean(searchParams.get(KandidatsokQueryParam.BrukKriterierFraStillingen));
 
 const useNavigeringsstate = () => {
     const [search, setSearch] = useSearchParams();
@@ -21,7 +22,7 @@ const useNavigeringsstate = () => {
         if (skalBrukeKriterierFraStillingen(search)) {
             setBrukKriterierFraStillingen(true);
 
-            search.delete(OtherParam.BrukKriterierFraStillingen);
+            search.delete(KandidatsokQueryParam.BrukKriterierFraStillingen);
             setSearch(search, {
                 replace: true,
             });

--- a/src/kandidatsok/hooks/useQuery.ts
+++ b/src/kandidatsok/hooks/useQuery.ts
@@ -7,6 +7,7 @@ import { søk } from '../api/api';
 import { byggQuery } from '../api/query/byggQuery';
 import { målQuery } from '../api/query/målQuery';
 import useSøkekriterier from './useSøkekriterier';
+import { KandidatsokQueryParam } from 'felles/lenker';
 
 export enum FilterParam {
     Fritekst = 'q',
@@ -28,13 +29,7 @@ export enum FilterParam {
     Sortering = 'sortering',
 }
 
-export enum OtherParam {
-    Stilling = 'stilling',
-    Kandidatliste = 'kandidatliste',
-    BrukKriterierFraStillingen = 'brukKriterierFraStillingen',
-}
-
-export type Param = FilterParam | OtherParam;
+export type Param = FilterParam | KandidatsokQueryParam;
 
 const useQuery = (
     innloggetBruker: InnloggetBruker

--- a/src/kandidatsok/hooks/useSøkekriterierFraStilling.ts
+++ b/src/kandidatsok/hooks/useSøkekriterierFraStilling.ts
@@ -6,8 +6,9 @@ import byggSuggestion, { Forslagsfelt } from '../api/query/byggSuggestion';
 import { encodeGeografiforslag } from '../filter/jobbønsker/ØnsketSted';
 import { Geografiforslag } from './useGeografiSuggestions';
 import { Stilling } from './useKontekstAvKandidatlisteEllerStilling';
-import { FilterParam, OtherParam } from './useQuery';
+import { FilterParam } from './useQuery';
 import useSøkekriterier, { LISTEPARAMETER_SEPARATOR } from './useSøkekriterier';
+import {KandidatsokQueryParam} from "felles/lenker";
 
 const useSøkekriterierFraStilling = (
     stilling: Nettressurs<Stilling>,
@@ -91,8 +92,8 @@ const hentFylkeskodeMedFylkesnavn = async (
 };
 
 const søkeKriterierIkkeLagtTil = (searchParams: URLSearchParams) =>
-    Array.from(searchParams.keys()).every((param) => param === OtherParam.Kandidatliste) ||
-    Array.from(searchParams.keys()).every((param) => param === OtherParam.Stilling);
+    Array.from(searchParams.keys()).every((param) => param === KandidatsokQueryParam.Kandidatliste) ||
+    Array.from(searchParams.keys()).every((param) => param === KandidatsokQueryParam.Stilling);
 
 const formaterStedsnavnSlikDetErRegistrertPåKandidat = (stedsnavn: string) =>
     stedsnavn

--- a/src/kandidatsok/kandidater/kandidatrad/Kandidatrad.tsx
+++ b/src/kandidatsok/kandidater/kandidatrad/Kandidatrad.tsx
@@ -45,9 +45,9 @@ const Kandidatrad: FunctionComponent<Props> = ({
               )
             : false;
 
-    const kandidatlisteId =
+    const stillingId =
         kontekstAvKandidatlisteEllerStilling?.kandidatliste.kind === Nettstatus.Suksess
-            ? kontekstAvKandidatlisteEllerStilling.kandidatliste.data.kandidatlisteId
+            ? kontekstAvKandidatlisteEllerStilling.kandidatliste.data.stillingId
             : undefined;
     return (
         <RekBisKortKandidat
@@ -80,7 +80,7 @@ const Kandidatrad: FunctionComponent<Props> = ({
             kandidat={
                 <Link
                     className={classNames(css.lenke, 'navds-link')}
-                    to={lenkeTilKandidat(kandidat.arenaKandidatnr, kandidatlisteId)}
+                    to={lenkeTilKandidat(kandidat.arenaKandidatnr, stillingId)}
                 >
                     {hentKandidatensNavn(kandidat)}
                 </Link>

--- a/src/kandidatsok/utils.ts
+++ b/src/kandidatsok/utils.ts
@@ -9,11 +9,11 @@ export const storForbokstav = (s: string | null) => {
         .join(' ');
 };
 
-export const lenkeTilKandidat = (kandidatnr: string, kandidatlisteId?: string) => {
+export const lenkeTilKandidat = (kandidatnr: string, stillingId?: string) => {
     let lenke = `/kandidater/kandidat/${kandidatnr}/cv?fraKandidatsok=true`;
 
-    if (kandidatlisteId) {
-        lenke += `&kandidatlisteId=${kandidatlisteId}`;
+    if (stillingId) {
+        lenke += `&stillingId=${stillingId}`;
     }
 
     return lenke;

--- a/src/stilling/stilling/Stilling.tsx
+++ b/src/stilling/stilling/Stilling.tsx
@@ -259,12 +259,7 @@ const Stilling = () => {
                 {harKandidatlisteSomKanÅpnes && (
                     <Tabs.Panel value="kandidater">
                         <Provider store={store}>
-                            <Kandidatlisteside
-                                skjulBanner={true}
-                                stillingsId={stilling.uuid}
-                                stilling={stilling}
-                                kandidatlisteId={kandidatlisteId}
-                            />
+                            <Kandidatlisteside skjulBanner={true} stilling={stilling} />
                         </Provider>
                     </Tabs.Panel>
                 )}

--- a/src/stilling/stilling/StillingKandidatKnapper.tsx
+++ b/src/stilling/stilling/StillingKandidatKnapper.tsx
@@ -37,7 +37,7 @@ const StillingKandidatKnapper: React.FC<IStillingKandidatKnapper> = ({
                 }}
             >
                 {erEier && (
-                    <Link to={lenkeTilFinnKandidater(stillingId, kandidatlisteId, true)}>
+                    <Link to={lenkeTilFinnKandidater(stillingId)}>
                         <Button as="div" icon={<MagnifyingGlassIcon aria-hidden />}>
                             Finn kandidater
                         </Button>


### PR DESCRIPTION
Slutt å putte `kandidatlisteId` inn i URLen til nettleservinduet. Har byttet ut bruken av `kandidatlsiteId` i query parameters med `stillingId`. Men har beholdt koden bakoverkompatibel enn så lenge.

Tenker vi kan fjerne bakoverkompabiliteten om en / noen dager?

Dette er første steget på å bli kvitt `kandidatlisteId` som en del av api-et til kandidat-api.
