### PR TITLE
Proxy kall for nytt kandidatvarsel-api

### DIFF
--- a/deploy/dev-gcp.json
+++ b/deploy/dev-gcp.json
@@ -15,7 +15,7 @@
 
     "statistikkApiUrl": "https://rekrutteringsbistand-statistikk-api.dev-fss-pub.nais.io/rekrutteringsbistand-statistikk-api",
     "kandidatApiUrl": "https://rekrutteringsbistand-kandidat-api.dev-fss-pub.nais.io/rekrutteringsbistand-kandidat-api/rest",
-    "smsApi": "https://rekrutteringsbistand-sms.dev-fss-pub.nais.io/rekrutteringsbistand-sms/sms",
+    "smsApi": "https://rekrutteringsbistand-sms.dev-fss-pub.nais.io/rekrutteringsbistand-sms",
     "foresporselOmDelingAvCvApi": "https://foresporsel-om-deling-av-cv-api.dev-fss-pub.nais.io",
     "modiaContextHolderApi": "https://modiacontextholder-q1.dev-fss-pub.nais.io/modiacontextholder"
 }

--- a/deploy/prod-gcp.json
+++ b/deploy/prod-gcp.json
@@ -15,7 +15,7 @@
 
     "statistikkApiUrl": "https://rekrutteringsbistand-statistikk-api.prod-fss-pub.nais.io/rekrutteringsbistand-statistikk-api",
     "kandidatApiUrl": "https://rekrutteringsbistand-kandidat-api.prod-fss-pub.nais.io/rekrutteringsbistand-kandidat-api/rest",
-    "smsApi": "https://rekrutteringsbistand-sms.prod-fss-pub.nais.io/rekrutteringsbistand-sms/sms",
+    "smsApi": "https://rekrutteringsbistand-sms.prod-fss-pub.nais.io/rekrutteringsbistand-sms",
     "foresporselOmDelingAvCvApi": "https://foresporsel-om-deling-av-cv-api.prod-fss-pub.nais.io",
     "modiaContextHolderApi": "https://modiacontextholder.prod-fss-pub.nais.io/modiacontextholder"
 }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -67,7 +67,8 @@ const startServer = () => {
     proxyMedOboToken('/stilling-api', STILLING_API_URL, scopes.stilling);
     proxyMedOboToken('/kandidat-api', KANDIDAT_API_URL, scopes.kandidat);
     proxyMedOboToken('/kandidatsok-api', KANDIDATSOK_API_URL, scopes.kandidatsøk);
-    proxyMedOboToken('/sms-api', SMS_API, scopes.sms);
+    proxyMedOboToken('/sms-api', `${SMS_API}/sms`, scopes.sms);
+    proxyMedOboToken('/kandidatvarsel-api', SMS_API, scopes.sms);
     proxyMedOboToken(
         '/foresporsel-om-deling-av-cv-api',
         FORESPORSEL_OM_DELING_AV_CV_API,


### PR DESCRIPTION
Setter opp nytt endepunkt i frackenden (`/kandidatvarsel-api`) som skal erstatte `sms-api` på sikt.

Foreløpig er det nye api-et implementert av samme backend som `sms-api`.

Testet i dev. Klar for deploy ✅ 