### PR TITLE
Fix console errors

### DIFF
--- a/src/felles/tilgangskontroll/TilgangskontrollForInnhold.tsx
+++ b/src/felles/tilgangskontroll/TilgangskontrollForInnhold.tsx
@@ -59,7 +59,7 @@ const TilgangskontrollForInnhold: React.FC<ITilgangskontrollForInnhold> = ({
                     <p>Du må ha en av følgende roller:</p>
                     <ul>
                         {kreverRoller.map((rolle) => (
-                            <li>{rolleTilNavn(rolle)}</li>
+                            <li key={rolle}>{rolleTilNavn(rolle)}</li>
                         ))}
                     </ul>
                 </div>

--- a/src/kandidatsok/kandidatlistebanner/Kandidatlistebanner.tsx
+++ b/src/kandidatsok/kandidatlistebanner/Kandidatlistebanner.tsx
@@ -65,7 +65,7 @@ const Kandidatlistebanner: FunctionComponent<Props> = ({ kontekst }) => {
                                 {kandidatliste.data.opprettetAv.ident})
                             </span>
                         ) : (
-                            <Skeleton width={100} />
+                            <Skeleton as="span" width={100} />
                         )}
                     </BodyShort>
                 </div>


### PR DESCRIPTION
`<Sceleton>` er som default en `<div>` og her puttes den inni en `<BodyShort>`, som er en`<p>`. Løsningen er å si at  `<Skeleton>` skal være en `<span>`, som er det elementet den står for er.