### PR TITLE
Eksponer kanal frontend

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
     deploy-til-dev:
         name: Deploy til dev-gcp
         needs: bygg-og-push-docker-image
-        if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/endre-person-ikke-funnet-tekst'
+        if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/eksponer-kanal-frontend'
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3

--- a/src/api/kandidatvarsel-api/kandidatvarsel.ts
+++ b/src/api/kandidatvarsel-api/kandidatvarsel.ts
@@ -176,6 +176,7 @@ export const kandidatvarselMock = [
                     opprettet: new Date().toISOString(),
                     minsideStatus: MinsideStatus.OPPRETTET,
                     eksternStatus: EksternStatus.VELLYKKET_SMS,
+                    eksternKanal: EksternKanal.SMS,
                 },
             ]);
         }

--- a/src/api/kandidatvarsel-api/kandidatvarsel.ts
+++ b/src/api/kandidatvarsel-api/kandidatvarsel.ts
@@ -34,11 +34,21 @@ export enum MinsideStatus {
     SLETTET = 'SLETTET',
 }
 
+export enum EksternKanal {
+    SMS = 'SMS',
+    EPOST = 'EPOST',
+}
+
 const MinsideStatusSchema = z
     .literal(MinsideStatus.IKKE_BESTILT)
     .or(z.literal(MinsideStatus.UNDER_UTSENDING))
     .or(z.literal(MinsideStatus.OPPRETTET))
     .or(z.literal(MinsideStatus.SLETTET));
+
+const EksternKanalSchema = z
+    .literal(null)
+    .or(z.literal(EksternKanal.SMS))
+    .or(z.literal(EksternKanal.EPOST));
 
 export enum EksternStatus {
     /** Vi jobber med å sende ut eksternt varsel. Status er ikke avklart enda. */
@@ -74,6 +84,7 @@ const SmsSchema = z
         minsideStatus: MinsideStatusSchema,
         eksternStatus: EksternStatusSchema,
         eksternFeilmelding: z.string().nullable(),
+        eksternKanal: EksternKanalSchema,
     })
     .partial({ eksternFeilmelding: true });
 
@@ -198,6 +209,7 @@ const smsExampleMock = {
     opprettet: new Date().toISOString(),
     minsideStatus: MinsideStatus.OPPRETTET,
     eksternStatus: EksternStatus.VELLYKKET_SMS,
+    eksternKanal: EksternKanal.SMS,
 };
 
 const mockSms: Sms[] = [smsExampleMock];

--- a/src/kandidat/kandidatliste/kandidatrad/status-og-hendelser/etiketter/Hendelsesetikett.module.css
+++ b/src/kandidat/kandidatliste/kandidatrad/status-og-hendelser/etiketter/Hendelsesetikett.module.css
@@ -14,6 +14,9 @@
 }
 
 .delt_med_kandidat,
+.ferdigstilt_sms,
+.ferdigstilt_epost,
+.epost_sendt,
 .sms_sendt {
     background-color: var(--a-deepblue-100);
     border-color: var(--a-deepblue-500);

--- a/src/kandidat/kandidatliste/kandidatrad/status-og-hendelser/etiketter/Hendelsesetikett.tsx
+++ b/src/kandidat/kandidatliste/kandidatrad/status-og-hendelser/etiketter/Hendelsesetikett.tsx
@@ -31,6 +31,7 @@ export enum Hendelse {
     EksternVarselFeilet = 'EKSTERN_VARSEL_FEILET',
     SmsSendt = 'SMS_SENDT',
     EpostSendt = 'EPOST_SENDT',
+    Ferdigstilt = 'FERDIGSTILT',
 }
 
 const Hendelsesetikett: FunctionComponent<Props> = ({
@@ -164,6 +165,9 @@ const hendelseTilLabel = (
         }
         case Hendelse.EksternVarselFeilet: {
             return `SMS/epost feilet – ${sms && formaterDatoUtenÅrstall(sms.opprettet)}`;
+        }
+        case Hendelse.Ferdigstilt: {
+            return `${sms?.eksternKanal === 'SMS' ? 'SMS sendt –' : 'Epost sendt –'} ${sms && formaterDatoUtenÅrstall(sms.opprettet)}`;
         }
         default:
             return '';

--- a/src/kandidat/kandidatliste/kandidatrad/status-og-hendelser/etiketter/Hendelsesetikett.tsx
+++ b/src/kandidat/kandidatliste/kandidatrad/status-og-hendelser/etiketter/Hendelsesetikett.tsx
@@ -1,5 +1,9 @@
 import { Kandidatutfall, Utfallsendring } from 'felles/domene/kandidatliste/KandidatIKandidatliste';
-import { EksternStatus, Sms } from '../../../../../api/kandidatvarsel-api/kandidatvarsel';
+import {
+    EksternKanal,
+    EksternStatus,
+    Sms,
+} from '../../../../../api/kandidatvarsel-api/kandidatvarsel';
 import moment from 'moment';
 import { FunctionComponent } from 'react';
 import { formaterDato, formaterDatoUtenÅrstall } from '../../../../utils/dateUtils';
@@ -31,7 +35,8 @@ export enum Hendelse {
     EksternVarselFeilet = 'EKSTERN_VARSEL_FEILET',
     SmsSendt = 'SMS_SENDT',
     EpostSendt = 'EPOST_SENDT',
-    Ferdigstilt = 'FERDIGSTILT',
+    FerdigstiltSms = 'FERDIGSTILT_SMS',
+    FerdigstiltEpost = 'FERDIGSTILT_EPOST',
 }
 
 const Hendelsesetikett: FunctionComponent<Props> = ({
@@ -94,6 +99,10 @@ export const hentKandidatensSisteHendelse = (
         return Hendelse.EpostSendt;
     } else if (sms?.eksternStatus === EksternStatus.FEIL) {
         return Hendelse.EksternVarselFeilet;
+    } else if (sms?.eksternKanal === EksternKanal.SMS) {
+        return Hendelse.FerdigstiltSms;
+    } else if (sms?.eksternKanal === EksternKanal.EPOST) {
+        return Hendelse.FerdigstiltEpost;
     }
 
     return Hendelse.NyKandidat;
@@ -166,8 +175,11 @@ const hendelseTilLabel = (
         case Hendelse.EksternVarselFeilet: {
             return `SMS/epost feilet – ${sms && formaterDatoUtenÅrstall(sms.opprettet)}`;
         }
-        case Hendelse.Ferdigstilt: {
-            return `${sms?.eksternKanal === 'SMS' ? 'SMS sendt –' : 'Epost sendt –'} ${sms && formaterDatoUtenÅrstall(sms.opprettet)}`;
+        case Hendelse.FerdigstiltSms: {
+            return `SMS sendt - ${sms && formaterDatoUtenÅrstall(sms.opprettet)}`;
+        }
+        case Hendelse.FerdigstiltEpost: {
+            return `Epost sendt - ${sms && formaterDatoUtenÅrstall(sms.opprettet)}`;
         }
         default:
             return '';


### PR DESCRIPTION
[Legger til kanal for om det er sms eller epost](https://github.com/navikt/rekrutteringsbistand/pull/269/commits/aa1c9b4d9f37fb8e4435e24a88ee7bc1cbaec2b8) 
[aa1c9b4](https://github.com/navikt/rekrutteringsbistand/pull/269/commits/aa1c9b4d9f37fb8e4435e24a88ee7bc1cbaec2b8)
Denne må brukes hvis hendelsen er ferdigstilt, siden i kandidatvarsel-api db så lagres kun siste hendelsesstatus og at sms eller epost er sendt vil da bli overskrevet av ferdigstilt hendelsen. Kanal lagres samtidig som sms eller epost sendt hendelsen, og den består selvom siste status er ferdigstilt og kan derfor brukes til å vise etikett for om sms eller epost er sendt.